### PR TITLE
fix(front):2/13の動作確認修正項目を全て修正

### DIFF
--- a/attendancemanagementsystem/src/main/java/com/example/attendancemanagementsystem/user/admin/controller/StudentDeleteRequestController.java
+++ b/attendancemanagementsystem/src/main/java/com/example/attendancemanagementsystem/user/admin/controller/StudentDeleteRequestController.java
@@ -40,7 +40,7 @@ public class StudentDeleteRequestController {
         }
         
         model.addAttribute("pageTitle", "生徒削除確認");
-        model.addAttribute("confirmMessage", "削除理由を入力してください（必須）");
+        model.addAttribute("confirmMessage", "変更内容を入力してください（必須）");
         model.addAttribute("studentList", studentList);
         model.addAttribute("approverList", deleteService.getApproverList()); 
         

--- a/attendancemanagementsystem/src/main/java/com/example/attendancemanagementsystem/user/admin/controller/StudentDepartmentRequestController.java
+++ b/attendancemanagementsystem/src/main/java/com/example/attendancemanagementsystem/user/admin/controller/StudentDepartmentRequestController.java
@@ -42,7 +42,7 @@ public class StudentDepartmentRequestController {
 
         model.addAttribute("mode", "course");
         model.addAttribute("pageTitle", "学科・コース変更申請");
-        model.addAttribute("confirmMessage", "変更理由を入力してください（任意）");
+        model.addAttribute("confirmMessage", "変更内容を入力してください（任意）");
         
         model.addAttribute("studentList", studentList);
         model.addAttribute("departmentList", departmentService.getDepartmentList());

--- a/attendancemanagementsystem/src/main/java/com/example/attendancemanagementsystem/user/admin/controller/StudentStatusRequestController.java
+++ b/attendancemanagementsystem/src/main/java/com/example/attendancemanagementsystem/user/admin/controller/StudentStatusRequestController.java
@@ -40,7 +40,7 @@ public class StudentStatusRequestController {
 
         // 画面表示に必要なデータをModelにセット
         model.addAttribute("pageTitle", "ステータス変更申請");
-        model.addAttribute("confirmMessage", "変更理由を入力してください（必須）");
+        model.addAttribute("confirmMessage", "変更内容を入力してください（必須）");
         model.addAttribute("studentList", studentList);
         model.addAttribute("approverList", statusService.getApproverList());
         model.addAttribute("statusList", statusService.getStatusList());

--- a/attendancemanagementsystem/src/main/resources/static/css/admin/requestDetail.css
+++ b/attendancemanagementsystem/src/main/resources/static/css/admin/requestDetail.css
@@ -27,7 +27,6 @@
     text-align: center;
     border-bottom: 2px solid #00bdca;
     padding-bottom: 10px;
-    font-size: 2rem;
     font-weight: bold;
     margin-bottom: 40px;
     color: #333;
@@ -152,4 +151,10 @@
     background-color: #f0f0f0;
     border-radius: 4px;
     color: #777;
+}
+
+.label{
+    font-size: 1.2em;
+    color: #00bdca !important;
+    margin: 20px 0 10px 0;
 }

--- a/attendancemanagementsystem/src/main/resources/static/css/admin/requestList.css
+++ b/attendancemanagementsystem/src/main/resources/static/css/admin/requestList.css
@@ -154,11 +154,3 @@
     font-weight: bold;
     color: #fff;
 }
-.status-badge {
-    display: inline-block;
-    padding: 4px 8px;
-    border-radius: 4px;
-    font-size: 0.85em;
-    color: #fff;
-    background-color: #28a745; /* 完了(緑) */
-}

--- a/attendancemanagementsystem/src/main/resources/static/css/admin/subjectList.css
+++ b/attendancemanagementsystem/src/main/resources/static/css/admin/subjectList.css
@@ -1,8 +1,5 @@
 @charset "UTF-8";
 
-/* 注意: .page-title, .main-container の設定は削除しました。
-   parts.css の共通デザインにお任せします。
-*/
 
 /* --- 検索・コントロールエリア --- */
 .top-controls {
@@ -11,7 +8,6 @@
     align-items: center;
     gap: 15px;
     margin-bottom: 20px;
-    /* padding-left: 20px; ← 削除（左端をコンテナと揃えるため） */
 }
 
 /* 検索フォームのデザイン */
@@ -70,7 +66,7 @@
     align-items: center;
     width: 40px;
     height: 40px;
-    border: 1px solid #00acbd;
+    border: 1px solid #00bdca;
     border-radius: 5px;
     background-color: #fff;
     transition: all 0.3s;
@@ -186,8 +182,8 @@
 
 .checkbox-1 input:checked + label::before, 
 .checkbox-1 label:has(:checked)::before {
-    background-color: #00acbd;
-    border-color: #00acbd;
+    background-color: #00bdca;
+    border-color: #00bdca;
     background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='white'%3E%3Cpath d='M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z'/%3E%3C/svg%3E");
 }
 
@@ -297,11 +293,11 @@
 }
 
 .full-width-link:hover .subject-name {
-    color: #00acbd;
+    color: #00bdca;
 }
 
 .full-width-link:hover .arrow-icon {
-    color: #00acbd;
+    color: #00bdca;
 }
 
 .no-data {
@@ -319,5 +315,5 @@
     font-weight: bold; 
     margin-bottom: 10px;
     font-size: 1.5em;
-    color: #00acbd;
+    color: #00bdca;
 }

--- a/attendancemanagementsystem/src/main/resources/static/css/common/notification.css
+++ b/attendancemanagementsystem/src/main/resources/static/css/common/notification.css
@@ -158,7 +158,7 @@ body {
 
 /* リンクスタイル */
 .notification-table a {
-    color: #007bff;
+    color: #00bdca;
     text-decoration: none;
 }
 .notification-table a:hover {
@@ -197,8 +197,8 @@ body {
 
 .modal-2__open-label:hover {
     background-color: #fff;
-    color: #2589d0;
-    outline: 1px solid #2589d0;
+    color: #00bdca;
+    outline: 1px solid #00bdca;
 }
 
 .modal-2 {
@@ -314,7 +314,7 @@ body {
 }
 
 .checkbox-1 label:has(:checked)::before {
-    background-color: #2589d0;
+    background-color: #00bdca;
 }
 
 .checkbox-1 label:has(:checked)::after {
@@ -366,7 +366,7 @@ body {
 
 /* 選択された時の背景色 */
 .radio-1 label:has(:checked)::before {
-    background-color: #2589d0;
+    background-color: #00bdca;
 }
 
 /* 選択された時の中心の白い点 */

--- a/attendancemanagementsystem/src/main/resources/static/css/common/subjectList.css
+++ b/attendancemanagementsystem/src/main/resources/static/css/common/subjectList.css
@@ -40,7 +40,7 @@
 
 .subject-name {
     font-size: 1.1em;
-    color: #039be5; 
+    color: #00bdca; 
     text-decoration: none;
     font-weight: 500;
 }

--- a/attendancemanagementsystem/src/main/resources/static/css/createAccount/manualInput.css
+++ b/attendancemanagementsystem/src/main/resources/static/css/createAccount/manualInput.css
@@ -36,7 +36,6 @@
     padding: 20px;
     border-radius: 8px;
     margin-bottom: 20px;
-    border-top: 5px solid #00bdca;
     box-shadow: 0 2px 5px rgba(0,0,0,0.05);
     text-align: left;
 }

--- a/attendancemanagementsystem/src/main/resources/static/css/student/date_attendance.css
+++ b/attendancemanagementsystem/src/main/resources/static/css/student/date_attendance.css
@@ -119,7 +119,7 @@ body {
 
 .subject-name {
     font-weight: bold;
-    color: #4da0b0; 
+    color: #00bdca; 
     font-size: 1.3rem;
     margin-bottom: 5px;
 }

--- a/attendancemanagementsystem/src/main/resources/static/js/admin/sadminCreate.js
+++ b/attendancemanagementsystem/src/main/resources/static/js/admin/sadminCreate.js
@@ -63,6 +63,15 @@ document.addEventListener("DOMContentLoaded", function () {
     });
   }
 
+  // 氏名の入力制限 
+  const nameInput = document.getElementById("userName"); 
+  if (nameInput) {
+    nameInput.addEventListener("input", function () {
+      // 半角スペース・全角スペースを空文字に置換
+      this.value = this.value.replace(/[ 　]+/g, "");
+    });
+  }
+
   // モーダル外クリックで閉じる
   const modal = document.getElementById("confirmModal");
   if (modal) {

--- a/attendancemanagementsystem/src/main/resources/static/js/admin/sadminInfo.js
+++ b/attendancemanagementsystem/src/main/resources/static/js/admin/sadminInfo.js
@@ -6,6 +6,15 @@ document.addEventListener("DOMContentLoaded", function () {
   const successMsg = document.getElementById("serverSuccessMessage");
   const errorMsg = document.getElementById("serverErrorMessage");
 
+// 氏名の入力制限 (スペースを削除)
+  const userNameInputForSanitize = document.getElementById("userName");
+  if (userNameInputForSanitize) {
+    userNameInputForSanitize.addEventListener("input", function () {
+      // 半角スペース・全角スペースを空文字に置換
+      this.value = this.value.replace(/[ 　]+/g, "");
+    });
+  }
+
   // 成功メッセージがあれば完了モーダルを表示
   if (successMsg && successMsg.value) {
     Swal.fire({

--- a/attendancemanagementsystem/src/main/resources/templates/admin/request/requestDeleteConfirm.html
+++ b/attendancemanagementsystem/src/main/resources/templates/admin/request/requestDeleteConfirm.html
@@ -108,7 +108,9 @@
             </div>
 
             <div class="remarks-area">
-                <label for="remarks">備考</label>
+                <label for="approver" style="font-weight: bold; display: block; margin-bottom: 5px;">
+                    変更内容<span style="color: red; font-size: 12px; margin-left: 5px;">必須</span>
+                </label>
                 <textarea id="remarks" class="remarks-input" 
                         th:placeholder="${confirmMessage}"></textarea>
             </div>

--- a/attendancemanagementsystem/src/main/resources/templates/admin/request/requestDepartmentConfirm.html
+++ b/attendancemanagementsystem/src/main/resources/templates/admin/request/requestDepartmentConfirm.html
@@ -131,7 +131,7 @@
             </div>
 
             <div class="remarks-area">
-                <label for="remarks">備考</label>
+                <label for="remarks">変更内容</label>
                 <textarea id="remarks" class="remarks-input" 
                         th:placeholder="${confirmMessage}"></textarea>
             </div>

--- a/attendancemanagementsystem/src/main/resources/templates/admin/request/requestDetail.html
+++ b/attendancemanagementsystem/src/main/resources/templates/admin/request/requestDetail.html
@@ -65,7 +65,7 @@
             </div>
 
             <div class="detail-row">
-                <div class="detail-label">備考・変更内容</div>
+                <div class="detail-label">変更内容</div>
                 <div class="detail-value" style="white-space: pre-wrap;" th:text="${detail.message}"></div>
             </div>
 

--- a/attendancemanagementsystem/src/main/resources/templates/admin/request/requestStatusConfirm.html
+++ b/attendancemanagementsystem/src/main/resources/templates/admin/request/requestStatusConfirm.html
@@ -132,7 +132,7 @@
 
             <div class="remarks-area">
                 <label for="approver" style="font-weight: bold; display: block; margin-bottom: 5px;">
-                    備考<span style="color: red; font-size: 12px; margin-left: 5px;">必須</span>
+                    変更内容<span style="color: red; font-size: 12px; margin-left: 5px;">必須</span>
                 </label>
                 <textarea id="remarks" class="remarks-input" 
                         th:placeholder="${confirmMessage}"></textarea>

--- a/attendancemanagementsystem/src/main/resources/templates/admin/superAdmin/requestDetail.html
+++ b/attendancemanagementsystem/src/main/resources/templates/admin/superAdmin/requestDetail.html
@@ -12,6 +12,7 @@
 
     <link rel="stylesheet" th:href="@{/css/parts.css}">
     <link rel="stylesheet" th:href="@{/css/admin/requestDetail.css}">
+    <link href="https://use.fontawesome.com/releases/v6.2.0/css/all.css" rel="stylesheet">
     
     <script src="https://cdn.jsdelivr.net/npm/sweetalert2@11"></script>
 </head>
@@ -26,26 +27,27 @@
 
     <main class="main-container">
 
-        <h2 class="page-title">申請詳細</h2>
+        <div th:replace="~{fragments/_parts :: page-title-part('申請詳細')}"></div>
 
         <div class="detail-card">
-            <h2>詳細情報</h2>
+            
+            <h2 >詳細情報</h2>
             
             <div class="info-group">
                 <div class="detail-item">
-                    <label>申請ID</label>
+                    <label class="label">申請ID</label>
                     <div class="value-box" th:text="${request.requestId}"></div>
                 </div>
                 
                 <div class="detail-item">
-                    <label>申請日時</label>
+                    <label class="label">申請日時</label>
                     <div class="value-box" th:text="${request.createdAt}"></div>
                 </div>
             </div>
 
             <div class="info-group">
                 <div class="detail-item">
-                    <label>申請者</label>
+                    <label class="label">申請者</label>
                     <div class="value-box">
                         <a th:href="@{/admin/studentInfo(id=${request.requesterId})}" 
                            th:text="${request.requesterName}" 
@@ -55,14 +57,14 @@
                 </div>
                 
                 <div class="detail-item">
-                    <label>申請種別</label>
+                    <label class="label">申請種別</label>
                     <div class="value-box" th:text="${request.typeName}"></div>
                 </div>
             </div>
 
             <div class="info-group">
                 <div class="detail-item">
-                    <label>ステータス</label>
+                    <label class="label">ステータス</label>
                     <span class="status-badge" 
                           th:classappend="'status-' + ${request.statusCode}"
                           th:text="${request.status}">
@@ -72,7 +74,7 @@
 
             <div class="info-group full-width" th:if="${request.details != null && !request.details.empty}">
                 <div class="detail-item full-width">
-                    <label>対象授業（公欠）</label>
+                    <label class="label">対象授業（公欠）</label>
                     <div class="table-container">
                         <table class="details-table">
                             <thead>
@@ -94,21 +96,21 @@
 
             <div class="info-group" th:if="${request.targetStatusId != null}">
                 <div class="detail-item">
-                    <label>変更後ステータスID</label>
+                    <label class="label">変更後ステータスID</label>
                     <div class="value-box" th:text="${request.targetStatusId}"></div>
                 </div>
             </div>
 
             <div class="info-group" th:if="${request.targetDepartmentId != null}">
                 <div class="detail-item">
-                    <label>変更後学科ID</label>
+                    <label class="label">変更後学科ID</label>
                     <div class="value-box" th:text="${request.targetDepartmentId}"></div>
                 </div>
             </div>
 
             <div class="info-group full-width">
                 <div class="detail-item full-width">
-                    <label>変更内容</label>
+                    <label class="label">変更内容</label>
                     <div class="value-box reason-box" th:text="${request.requestMessage}"></div>
                 </div>
             </div>

--- a/attendancemanagementsystem/src/main/resources/templates/createAccount/manualInput.html
+++ b/attendancemanagementsystem/src/main/resources/templates/createAccount/manualInput.html
@@ -84,16 +84,16 @@
                         <tr>
                             <td class="row-num">1</td>
                             <td>
-                                <input type="text" name="accounts[0].studentNumber" placeholder="ST001" 
+                                <input type="text" name="accounts[0].studentNumber" placeholder="ID(50文字)" 
                                        required oninput="sanitizeId(this)" />
                             </td>
                             <td>
-                                <input type="text" name="accounts[0].name" placeholder="例: 山田太郎" 
+                                <input type="text" name="accounts[0].name" placeholder="氏名(255文字)" 
                                        required oninput="sanitizeName(this)" />
                             </td>
                             <td>
                                 <input type="text" name="accounts[0].password" 
-                                       placeholder="パスワード" required autocomplete="off"
+                                       placeholder="パスワード(255文字)" required autocomplete="off"
                                        oninput="sanitizePassword(this)" />
                             </td>
                             <td class="action-cell">


### PR DESCRIPTION
管理者
・申請履歴のステータスの色を修正
・生徒操作系の「備考」→「変更内容」に修正
上位管理者
・申請詳細のレイアウトを修正
・手動仮アカ登録の入力欄の文字を統一
・管理者作成、編集の氏名項目に空白を入れないように修正
生徒
・教科一覧のリンクの色修正
共通
・通知のリンクの色修正